### PR TITLE
login/logout doesn't work for subdomains

### DIFF
--- a/book/cookies.md
+++ b/book/cookies.md
@@ -83,11 +83,20 @@ $config = [
         'request' => [
             'cookieValidationKey' => 'your_validation_key'
         ],
+        'session' => [
+            'cookieParams' => [
+                'domain' => '.example.com',
+                'httpOnly' => true,
+            ],
+        ],
+
     ],
 ];
 ```
 
 Note that `cookieValidationKey` should be the same for all sub-domains.
+
+Note that you have to configure the `session::cookieParams` property to have the samedomain as your `user::identityCookie` to ensure the `login` and `logout` work for all subdomains. This behavior is better explained on the next section.
 
 Session cookie parameters
 -------------------------


### PR DESCRIPTION
the documented example doesn't allow properly login/logout between submains, the session must be organized so that it works the same among the subdomains where the user identity cookie is active.