### PR TITLE
wrong var to print_r

### DIFF
--- a/book/urls-variable-number-of-parameters.md
+++ b/book/urls-variable-number-of-parameters.md
@@ -46,7 +46,7 @@ class ProductController extends Controller
     public function actionCategory($categories)
     {
         $params = explode('/', $categories);
-        print_r($categories);
+        print_r($params);
     }
 }
 ```


### PR DESCRIPTION
print_r($params)       // output: Array ( [0] => cars [1] => sport)
print_r($categories)  // output: cars/sport

Nice trick by the way ;-) thanks for sharing it