### PR TITLE
Update urls-variable-number-of-parameters.md

### DIFF
--- a/book/urls-variable-number-of-parameters.md
+++ b/book/urls-variable-number-of-parameters.md
@@ -30,7 +30,11 @@ Now in `config/urls.php` add the following content:
 ```php
 <?php
 return [
-    'products/<categories:.*>' => 'product/category',
+    [
+        'pattern' => 'products/<categories:.*>',
+        'route' => 'product/category',
+        'encodeParams' => false,
+    ],
 ];
 ```
 


### PR DESCRIPTION
`Url::to(['product/category', 'categories' => 'cars/sport']) ` returns `/products/cars%2Fsport`.
In order to get `/products/cars/sport`, the rule should be configured a bit differently.