### PR TITLE
Add validation example has no validation function

### DIFF
--- a/book/forms-activeform-js.md
+++ b/book/forms-activeform-js.md
@@ -61,7 +61,10 @@ $('#contact-form').yiiActiveForm('add', {
     'name': 'address',
     'container': '.field-address',
     'input': '#address',
-    'error': '.field-address .help-block'
+    'error': '.field-address .help-block',
+    "validate":  function (attribute, value, messages, deferred, $form) {
+        yii.validation.required(value, messages, {"message": "Validation Message Here"});
+    }
 });
 ```
 


### PR DESCRIPTION
Add validation example has no validation method which does not make any sense (as I can understand).
It is not clear how to use it without digging into the yiiActiveForm code.
Used this answer as an example for the suggested change.
http://stackoverflow.com/a/30882515/4923688
