### PR TITLE
Field error attribute is relative to container

### DIFF
--- a/book/forms-activeform-js.md
+++ b/book/forms-activeform-js.md
@@ -61,7 +61,7 @@ $('#contact-form').yiiActiveForm('add', {
     'name': 'address',
     'container': '.field-address',
     'input': '#address',
-    'error': '.field-address .help-block'
+    'error': '.help-block'
 });
 ```
 


### PR DESCRIPTION
Error element selector is relative to field container. So specifying container selector there will not work. It may confuse readers.
See **yii.activeForm.js** to confirm this.
`// the jQuery selector of the error tag under the context of the container`